### PR TITLE
Formattable & Parseable

### DIFF
--- a/Sources/SwiftFormats/FormatStyle+CoreGraphics.swift
+++ b/Sources/SwiftFormats/FormatStyle+CoreGraphics.swift
@@ -2,7 +2,7 @@ import CoreGraphics
 import Foundation
 
 /// Format `CGPoint`s.
-public struct CGPointFormatStyle: ParseableFormatStyle {
+public struct CGPointFormatStyle: ParseableFormatStyle, InitializableFormatStyle {
 
     public var parseStrategy: CGPointParseStrategy {
         return CGPointParseStrategy(componentFormat: componentFormat)
@@ -10,18 +10,11 @@ public struct CGPointFormatStyle: ParseableFormatStyle {
 
     public var componentFormat: FloatingPointFormatStyle<Double> = .number
 
-    public init() {
-    }
+    public init() {}
 
     public func format(_ value: CGPoint) -> String {
         let style = SimpleListFormatStyle(substyle: componentFormat)
         return style.format([value.x, value.y])
-    }
-}
-
-public extension FormatStyle where Self == CGPointFormatStyle {
-    static func point() -> Self {
-        return Self()
     }
 }
 
@@ -44,12 +37,22 @@ public struct CGPointParseStrategy: ParseStrategy {
 
 // MARK: -
 
-public extension CGPoint {
-    func formatted<S>(_ format: S) -> S.FormatOutput where Self == S.FormatInput, S : FormatStyle {
-        return format.format(self)
-    }
+public extension FormatStyle where Self == CGPointFormatStyle {
+    static var point: Self { .init() }
+}
 
-    func formatted() -> String {
-        formatted(CGPointFormatStyle())
-    }
+// MARK: -
+
+public extension ParseableFormatStyle where Self == CGPointFormatStyle {
+    static var point: Self { .init() }
+}
+
+public extension ParseStrategy where Self == CGPointParseStrategy {
+    static var point: Self { .init() }
+}
+
+// MARK: -
+
+extension CGPoint: StringFormattable, StringParseable {
+    public typealias Format = CGPointFormatStyle
 }

--- a/Sources/SwiftFormats/Protocols/Formattable+String.swift
+++ b/Sources/SwiftFormats/Protocols/Formattable+String.swift
@@ -1,0 +1,10 @@
+//
+//  StringFormattable.swift
+//  
+//
+//  Created by brett ohland on 02/04/23.
+//
+
+import Foundation
+
+public protocol StringFormattable: Formattable where Format.FormatOutput == String {}

--- a/Sources/SwiftFormats/Protocols/Formattable.swift
+++ b/Sources/SwiftFormats/Protocols/Formattable.swift
@@ -1,0 +1,26 @@
+//
+//  Formattable.swift
+//  
+//
+//  Created by brett ohland on 02/04/23.
+//
+
+import Foundation
+
+public protocol Formattable {
+    associatedtype Format: InitializableFormatStyle
+}
+
+public protocol InitializableFormatStyle: ParseableFormatStyle {
+    init()
+}
+
+public extension Formattable {
+    func formatted(_ format: Format) -> Format.FormatOutput where Format.FormatInput == Self {
+        format.format(self)
+    }
+
+    func formatted() -> Format.FormatOutput where Format.FormatInput == Self {
+        Format().format(self)
+    }
+}

--- a/Sources/SwiftFormats/Protocols/Parseable+String.swift
+++ b/Sources/SwiftFormats/Protocols/Parseable+String.swift
@@ -1,0 +1,17 @@
+//
+//  StringParseable.swift
+//  
+//
+//  Created by brett ohland on 02/04/23.
+//
+
+import Foundation
+
+/// Describes the ability to parse a given type from a String
+public protocol StringParseable: Parseable where Format.Strategy.ParseInput == String, Format.Strategy.ParseOutput == Self {}
+
+public extension StringParseable where Format.FormatInput == Self {
+    init<ParseInput>(_ input: ParseInput) throws where ParseInput: StringProtocol {
+        self = try Format().parseStrategy.parse(String(input))
+    }
+}

--- a/Sources/SwiftFormats/Protocols/Parseable.swift
+++ b/Sources/SwiftFormats/Protocols/Parseable.swift
@@ -1,0 +1,19 @@
+//
+//  Parseable.swift
+//  
+//
+//  Created by brett ohland on 02/04/23.
+//
+
+import Foundation
+
+public protocol Parseable: Formattable {}
+
+public extension Parseable {
+    init<ParseInput, Format>(_ input: ParseInput, format: Format) throws where Format: ParseableFormatStyle, ParseInput == Format.Strategy.ParseInput, Self == Format.Strategy.ParseOutput {
+        self = try format.parseStrategy.parse(input)
+    }
+    init<ParseInput, Strategy>(_ input: ParseInput, strategy: Strategy) throws where Strategy: ParseStrategy, ParseInput == Strategy.ParseInput, Self == Strategy.ParseOutput {
+        self = try strategy.parse(input)
+    }
+}


### PR DESCRIPTION
As per the discussion on the other PR, here's a take on a set of protocols to add simple `.formatted` and some basic initializers that can be used anytime a simple type (without any sort of customizations).