### PR TITLE
Adding Angle Parsing

### DIFF
--- a/Sources/SwiftFormats/FormatStyle+Angles.swift
+++ b/Sources/SwiftFormats/FormatStyle+Angles.swift
@@ -39,7 +39,7 @@ public struct DegreesMinutesSecondsNotationFormatStyle<FormatInput>: FormatStyle
         case .decimalSeconds:
             let degrees = floor(value)
             let minutes = floor(60 * (value - degrees))
-            let seconds = 3600 * (value - degrees) - 60 * minutes
+            let seconds = 3_600 * (value - degrees) - 60 * minutes
             return "\(degrees, unit: UnitAngle.degrees, format: measurementStyle) \(minutes, unit: UnitAngle.arcMinutes, format: measurementStyle) \(seconds, unit: UnitAngle.arcSeconds, format: measurementStyle)"
         }
     }
@@ -57,12 +57,10 @@ public extension FormatStyle where Self == DegreesMinutesSecondsNotationFormatSt
     }
 }
 
-// TODO: SwiftUI.Angle
-
 // MARK: -
 
 /// Format angles in degrees or radians, input and output units can be different.
-public struct AngleFormatStyle<FormatInput>: FormatStyle where FormatInput: BinaryFloatingPoint {
+public struct AngleFormatStyle<FormatInput>: ParseableFormatStyle where FormatInput: BinaryFloatingPoint {
     public static var defaultMeasurementStyle: Measurement<UnitAngle>.FormatStyle {
         .measurement(width: .narrow)
     }
@@ -75,23 +73,62 @@ public struct AngleFormatStyle<FormatInput>: FormatStyle where FormatInput: Bina
     public var inputUnit: Unit
     public var outputUnit: Unit
     public var measurementStyle: Measurement<UnitAngle>.FormatStyle
+    public var locale: Locale
 
-    public init(inputUnit: AngleFormatStyle<FormatInput>.Unit, outputUnit: AngleFormatStyle<FormatInput>.Unit, measurementStyle: Measurement<UnitAngle>.FormatStyle = Self.defaultMeasurementStyle) {
+    public var parseStrategy: AngleParseStrategy<FormatInput> {
+        AngleParseStrategy(inputUnit: inputUnit, outputUnit: outputUnit, locale: locale)
+    }
+
+    public init(
+        inputUnit: AngleFormatStyle<FormatInput>.Unit,
+        outputUnit: AngleFormatStyle<FormatInput>.Unit,
+        measurementStyle: Measurement<UnitAngle>.FormatStyle = Self.defaultMeasurementStyle,
+        locale: Locale = .autoupdatingCurrent
+    ) {
         self.inputUnit = inputUnit
         self.outputUnit = outputUnit
         self.measurementStyle = measurementStyle
+        self.locale = locale
     }
 
     public func format(_ value: FormatInput) -> String {
         switch (inputUnit, outputUnit) {
         case (.degrees, .degrees):
-            return "\(Double(value), unit: UnitAngle.degrees, format: measurementStyle)"
+            return "\(Double(value), unit: UnitAngle.degrees, format: measurementStyle.locale(locale))"
         case (.radians, .radians):
-            return "\(Double(value), unit: UnitAngle.radians, format: measurementStyle)"
+            return "\(Double(value), unit: UnitAngle.radians, format: measurementStyle.locale(locale))"
         case (.degrees, .radians):
-            return "\(degreesToRadians(Double(value)), unit: UnitAngle.radians, format: measurementStyle)"
+            return "\(degreesToRadians(Double(value)), unit: UnitAngle.radians, format: measurementStyle.locale(locale))"
         case (.radians, .degrees):
-            return "\(radiansToDegrees(Double(value)), unit: UnitAngle.degrees, format: measurementStyle)"
+            return "\(radiansToDegrees(Double(value)), unit: UnitAngle.degrees, format: measurementStyle.locale(locale))"
+        }
+    }
+}
+
+public struct AngleParseStrategy<ParseOutput>: ParseStrategy where ParseOutput: BinaryFloatingPoint {
+
+    public typealias Unit = AngleFormatStyle<ParseOutput>.Unit
+
+    public let inputUnit: Unit
+    public let outputUnit: Unit
+    public let locale: Locale
+
+    init(inputUnit: Unit, outputUnit: Unit, locale: Locale = .autoupdatingCurrent) {
+        self.inputUnit = inputUnit
+        self.outputUnit = outputUnit
+        self.locale = locale
+    }
+
+    public func parse(_ value: String) throws -> ParseOutput {
+        let number = try Double(value, format: .number)
+        switch (inputUnit, outputUnit) {
+        case (.degrees, .degrees),
+             (.radians, .radians):
+            return ParseOutput(number)
+        case (.degrees, .radians):
+            return ParseOutput(degreesToRadians(number))
+        case (.radians, .degrees):
+            return ParseOutput(radiansToDegrees(number))
         }
     }
 }
@@ -102,25 +139,14 @@ public extension FormatStyle where Self == AngleFormatStyle<Double> {
     }
 }
 
-// TODO: Measurement doesn't support parsing, so we may need to implement our own parsing strategy. Possible only for english locale.
-
-/*
-public struct AngleParseStrategy <ParseOutput>: ParseStrategy where ParseOutput: BinaryFloatingPoint {
-
-    public typealias Unit = AngleFormatStyle<ParseOutput>.Unit
-
-    public var outputUnit: Unit
-//    public var measurementStyle: Measurement<UnitAngle>.FormatStyle
-
-    public func parse(_ value: String) throws -> ParseOutput {
-
-
-
-
-
-
-        fatalError()
+public extension ParseStrategy where Self == AngleParseStrategy<Double> {
+    static func angle(inputUnit: AngleFormatStyle<Double>.Unit, outputUnit: AngleFormatStyle<Double>.Unit, locale: Locale = .autoupdatingCurrent) -> Self {
+        Self(inputUnit: inputUnit, outputUnit: outputUnit, locale: locale)
     }
-
 }
-*/
+
+public extension BinaryFloatingPoint {
+    init(_ value: String, format: AngleFormatStyle<Self>) throws {
+        self = try format.parseStrategy.parse(value)
+    }
+}

--- a/Sources/SwiftFormats/ParseableFormatStyle+Measurement.swift
+++ b/Sources/SwiftFormats/ParseableFormatStyle+Measurement.swift
@@ -1,0 +1,134 @@
+//
+//  ParseableFormatStyle+Measurement.swift
+//
+//
+//  Created by brett ohland on 02/25/23.
+//
+
+import Foundation
+
+public struct UnitAngleParseStrategy {
+
+    public enum ParsingError: Error {
+        case unitCannotBeDetermined
+    }
+
+    /// The format style's locale and (optionally) the unit's width width to be used to match the candidate unit.
+    let format: Measurement<UnitAngle>.FormatStyle
+    /// Determines how strict the unit parsing detection will be.
+    /// If `False`: The candidate unit will be case-sensitive matched against the format's `Measurement<UnitAngle>.FormatStyle.UnitWidth` value.
+    /// if `True`: The candidate unit will be case-insensitive matched against all possible `Measurement<UnitAngle>.FormatStyle.UnitWidth` values.
+    let lenient: Bool
+
+    init(format: Measurement<UnitAngle>.FormatStyle, lenient: Bool = false) {
+        self.format = format
+        self.lenient = lenient
+    }
+
+    public func lenient(_ isLenient: Bool) -> UnitAngleParseStrategy {
+        UnitAngleParseStrategy(format: format, lenient: isLenient)
+    }
+}
+
+// MARK: - ParseStrategy
+
+extension UnitAngleParseStrategy: ParseStrategy {
+    public func parse(_ value: String) throws -> Measurement<UnitAngle> {
+        let parsedUnit = try parseUnit(from: value, for: format.locale)
+        let numericalValue = try Double(value, format: format.numberFormatStyle ?? .number)
+        return Measurement<UnitAngle>(value: numericalValue , unit: parsedUnit)
+    }
+}
+
+// MARK: - Private Methods
+
+private extension UnitAngleParseStrategy {
+    private func parseUnit(from string: String, for locale: Locale) throws -> UnitAngle {
+        let matchingUnit = try UnitAngle.allFoundationUnits.first { candidateUnit in
+            let checkWidths = lenient ? [format.width] : Measurement<UnitAngle>.FormatStyle.UnitWidth.allCases
+            let unitStrings = try candidateUnit.localizedUnitStrings(for: locale, widths: checkWidths)
+            switch lenient {
+            case true:
+                return unitStrings.map({$0.lowercased()}).contains(where: { string.contains($0.lowercased()) })
+            case false:
+                return unitStrings.contains(where: { string.contains($0) })
+            }
+
+        }
+        guard let matchingUnit else {
+            throw ParsingError.unitCannotBeDetermined
+        }
+        return matchingUnit
+    }
+}
+
+// MARK: - Convenience Initializers
+
+extension Measurement.FormatStyle: ParseableFormatStyle where UnitType == UnitAngle {
+    public var parseStrategy: UnitAngleParseStrategy {
+        UnitAngleParseStrategy(format: self, lenient: false)
+    }
+}
+
+public extension Measurement where UnitType == UnitAngle {
+    init(_ value: String, format: Measurement<UnitAngle>.FormatStyle, lenient: Bool = false) throws {
+        self = try format.parseStrategy.lenient(lenient).parse(value)
+    }
+
+    init(_ value: String, locale: Locale = .autoupdatingCurrent) throws {
+        self = try Measurement<UnitAngle>.FormatStyle.measurement(width: .wide).locale(locale).parseStrategy.parse(value)
+    }
+}
+
+// MARK: - UnitAngle Extensions
+
+public extension UnitAngle {
+    static var allFoundationUnits: [UnitAngle] {
+        [
+            .degrees,
+            .radians,
+            .arcMinutes,
+            .arcSeconds,
+            .gradians,
+            .revolutions,
+        ]
+    }
+}
+
+extension UnitAngle {
+
+    private static var whitespaceNewlinesAndCharacterForZero: CharacterSet {
+        var set = CharacterSet()
+        set.insert(charactersIn: "0")
+        set.formUnion(.whitespacesAndNewlines)
+        return set
+    }
+
+    func localizedUnitString(for locale: Locale, width: Measurement<UnitAngle>.FormatStyle.UnitWidth) throws -> String {
+        // Create a zero value measurement to feed into the Measurement.FormatStyle
+        let dummyMeasurement = Measurement<UnitAngle>(value: 0, unit: self)
+        let formattedString = dummyMeasurement.formatted(.measurement(width: width).locale(locale))
+
+        // Remove only whitespace characters and the "0" character from the string. Leaving only the localized unit
+        return String(formattedString.components(separatedBy: Self.whitespaceNewlinesAndCharacterForZero).joined())
+    }
+
+    func localizedUnitStrings(
+        for locale: Locale,
+        widths: [Measurement<UnitAngle>.FormatStyle.UnitWidth]
+    ) throws -> [String] {
+        try widths.map { try localizedUnitString(for: locale, width: $0) }
+    }
+}
+
+// MARK: - Measurement Extensions
+
+extension Measurement<UnitAngle>.FormatStyle.UnitWidth: CaseIterable {
+    public static var allCases: [Self] {
+        [
+            .wide,
+            .abbreviated,
+            .narrow
+        ]
+    }
+}

--- a/Tests/SwiftFormatsTests/SwiftFormatsTests.swift
+++ b/Tests/SwiftFormatsTests/SwiftFormatsTests.swift
@@ -43,14 +43,66 @@ class DMSTests: XCTestCase {
 }
 
 class AngleTests: XCTestCase {
-    func test1() {
+    func test1() throws {
         XCTAssertEqual(45.25125.formatted(.dmsNotation().locale(locale)), "45.25125°")
-        XCTAssertEqual("\(45.25125, format: .angle(inputUnit: .degrees, outputUnit: .degrees).locale(locale))", "45.25125°")
-
         XCTAssertEqual("\(45.25125, format: .angle(inputUnit: .degrees, outputUnit: .degrees).locale(locale))", "45.25125°")
         XCTAssertEqual("\(45.25125, format: .angle(inputUnit: .degrees, outputUnit: .radians).locale(locale))", "0.789783rad")
         XCTAssertEqual("\(0.789783, format: .angle(inputUnit: .radians, outputUnit: .degrees).locale(locale))", "45.251233°")
         XCTAssertEqual("\(0.789783, format: .angle(inputUnit: .radians, outputUnit: .radians).locale(locale))", "0.789783rad")
+        XCTAssertEqual(45.25125.formatted(.dmsNotation().locale(locale)), "45.25125°")
+        XCTAssertEqual(45.25125.formatted(.angle(inputUnit: .degrees, outputUnit: .radians)), "0.789783rad")
+
+        XCTAssertEqual(try AngleParseStrategy(inputUnit: .degrees, outputUnit: .degrees).parse("45.25125°"), 45.25125)
+        XCTAssertEqual(try AngleParseStrategy(inputUnit: .degrees, outputUnit: .radians).parse("45.25125°"), 0.789783303143084)
+        XCTAssertEqual(try AngleParseStrategy(inputUnit: .radians, outputUnit: .radians).parse("0.789783rad"), 0.789783)
+        XCTAssertEqual(try AngleParseStrategy(inputUnit: .radians, outputUnit: .degrees).parse("0.789783rad"), 45.2512326311807)
+
+        XCTAssertEqual(try Double("45.25125°", strategy: .angle(inputUnit: .degrees, outputUnit: .degrees)), 45.25125)
+        XCTAssertEqual(try Double("45.25125°", strategy: .angle(inputUnit: .degrees, outputUnit: .radians)), 0.789783303143084)
+        XCTAssertEqual(try Double("0.789783 rad", strategy: .angle(inputUnit: .radians, outputUnit: .radians)), 0.789783)
+        XCTAssertEqual(try Double("0.789783 rad", strategy: .angle(inputUnit: .radians, outputUnit: .degrees)), 45.2512326311807)
+
+        XCTAssertEqual(try Double("0.789783 radian", strategy: .angle(inputUnit: .radians, outputUnit: .radians, locale: Locale(identifier: "fr_FR"))), 0.789783)
+        XCTAssertEqual(try Double("10", format: .number), 10)
+
+        XCTAssertEqual(try Double("0.789783 radian", format: .angle(inputUnit: .radians, outputUnit: .degrees)), 45.2512326311807)
+    }
+}
+
+class UnitAngleMeasurementTests: XCTestCase {
+
+    func testParsing() throws {
+
+        let testMeasurement = Measurement<UnitAngle>(value: 45.0, unit: UnitAngle.degrees)
+
+        let englishUS = Locale(identifier: "en_US")
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", format: .measurement(width: .narrow).locale(englishUS)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 deg", format: .measurement(width: .abbreviated).locale(englishUS)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 degrees", format: .measurement(width: .wide).locale(englishUS)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", locale: englishUS), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 deg", locale: englishUS), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 degrees", locale: englishUS), testMeasurement)
+
+        let frenchFR = Locale(identifier: "fr_FR")
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", format: .measurement(width: .narrow).locale(frenchFR)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", format: .measurement(width: .abbreviated).locale(frenchFR)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 degrés", format: .measurement(width: .wide).locale(frenchFR)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", locale: frenchFR), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 degrés", locale: frenchFR), testMeasurement)
+
+        let japaneseJP = Locale(identifier: "ja_JP")
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", format: .measurement(width: .narrow).locale(japaneseJP)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45度", format: .measurement(width: .abbreviated).locale(japaneseJP)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45度", format: .measurement(width: .wide).locale(japaneseJP)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", locale: japaneseJP), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45度", locale: japaneseJP), testMeasurement)
+
+        let hindiID = Locale(identifier: "id_HI")
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", format: .measurement(width: .narrow).locale(hindiID)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", format: .measurement(width: .abbreviated).locale(hindiID)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 derajat", format: .measurement(width: .wide).locale(hindiID)), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45°", locale: hindiID), testMeasurement)
+        XCTAssertEqual(try Measurement<UnitAngle>("45 derajat", locale: hindiID), testMeasurement)
     }
 }
 


### PR DESCRIPTION
I've gotten the `AngleFormatStyle` to conform to `ParseableFormatStyle`, but the implementation is pretty limited since you have to pass in the input and output units. However, since the `AngleFormatStyle` requires these values, it's a valid use case.

The more interesting one (to me at least) is the addition of a UnitAngle parsing style on `Measurement`. It  handles localization, and works out quite well but the code is almost certainly the epitome of the saying "If it's stupid and it works, it's not stupid".

Essentially it uses the associated `Measurement<UnitAngle>.FormatStyle` to first convert a zero value measurement into a string, and then match that with the incoming candidate unit string. It's almost certainly not performant enough for lower level use-cases. But for UI it's almost certainly good enough.

